### PR TITLE
Fix: Remove header gradient background to reveal video

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,8 +208,8 @@
       aria-hidden="true"
     ></video>
 
-    <!-- 头部专用渐变层 (z-index: -3) -->
-    <div id="header-gradient-bg"></div>
+    <!-- 头部专用渐变层 (z-index: -3) - 已注释以显示视频背景 -->
+    <!-- <div id="header-gradient-bg"></div> -->
 
     <!-- ============================================ -->
     <!-- 动态交互效果：粒子背景 + 光标辉光 -->


### PR DESCRIPTION
Commented out the #header-gradient-bg element that was blocking the background video (#bgVideo) from being visible. The fixed-position gradient layer (z-index: -3) was sitting above the video layer (z-index: -10) and obscuring it with a dark gradient.